### PR TITLE
fix: include mapbox token in docker build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       CONTAINER_REPOSITORY: ghcr.io/abumah1r/sf-food-trucks
       GITHUB_TOKEN: ${{ secrets.SF_FOOD_TRUCKS_GITHUB_TOKEN }}
+      VITE_MAPBOX_TOKEN: ${{ secrets.VITE_MAPBOX_TOKEN }}
 
     steps:
       - name: checkout repo
@@ -25,7 +26,7 @@ jobs:
         run: |
           IMAGE_NAME=${{ env.CONTAINER_REPOSITORY }}:${{ github.sha }}
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
-          docker build -t $IMAGE_NAME .
+          docker build --build-arg VITE_MAPBOX_TOKEN=${{ env.VITE_MAPBOX_TOKEN }} -t $IMAGE_NAME .
           docker push $IMAGE_NAME
 
       - name: set up flyctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,17 @@ ARG NODE_VERSION=22.18.0
 FROM node:${NODE_VERSION}-slim AS base
 
 LABEL fly_launch_runtime="Node.js"
-LABEL org.opencontainers.image.source https://github.com/abumah1r/sf-food-trucks
+LABEL org.opencontainers.image.source="https://github.com/abumah1r/sf-food-trucks"
 
 WORKDIR /app
 
 ENV NODE_ENV="production"
 
 FROM base AS build
+
+# TIL vite env variables are bundled at build time
+ARG VITE_MAPBOX_TOKEN
+ENV VITE_MAPBOX_TOKEN=$VITE_MAPBOX_TOKEN
 
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3 && \


### PR DESCRIPTION
🕵️ 🐳 **Dockerfile & CD Pipeline: Fixed Vite Environment Variable Handling**

This PR updates the Dockerfile and CD pipeline to properly pass `VITE_MAPBOX_TOKEN` as a build argument.

**The Problem:**
Vite bundles environment variables at build time, not runtime. My Docker setup wasn't passing the Mapbox token during the build stage, so production was failing to load maps

**What I Learned:**
Spent some quality time debugging why maps worked locally but exploded in production. Turns out Vite reads env vars during `npm run build`, not when the container starts.

**Testing Process:**
- Built image without build args (replicating old behavior) → Same errors ❌
- Built image with `--build-arg VITE_MAPBOX_TOKEN` → Maps render correctly ✅
- Confirmed the fix works locally before updating CD

**Changes:**
- **Dockerfile**: Added `ARG` and `ENV` for `VITE_MAPBOX_TOKEN` in build stage
- **CD**: Updated docker build command to pass the token as a build argument

Now Vite gets its token when it actually needs it (build time), and the food truck maps are back in business.